### PR TITLE
Abdulwaisa/set cookie cors options

### DIFF
--- a/Portify.API/Program.cs
+++ b/Portify.API/Program.cs
@@ -1,4 +1,5 @@
 using Portify.API.Startup;
+using Portify.Infrastructure.Configuration.Settings;
 
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
@@ -15,6 +16,8 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
+
+app.UseCors(CorsOptions.PolicyName);
 
 app.UseAuthentication();
 

--- a/Portify.API/Startup/ServiceConfiguration.cs
+++ b/Portify.API/Startup/ServiceConfiguration.cs
@@ -29,6 +29,7 @@ public class ServiceConfiguration
         // Add other shared services here
         AddServices(services);
         AddDatabase(services, configuration);
+        AddCorsPolicy(services, configuration);
 
 
     }
@@ -91,6 +92,21 @@ public class ServiceConfiguration
         services.AddScoped<IApplicationDbContext>(provider => provider.GetRequiredService<PortifyDbContext>());
     }
 
+    private static void AddCorsPolicy(IServiceCollection services, IConfiguration configuration)
+    {
+        CorsOptions corsOptions = configuration.GetSection(CorsOptions.SectionName).Get<CorsOptions>()!;
+
+        services.AddCors(options =>
+        {
+            options.AddPolicy(CorsOptions.PolicyName, policy =>
+            {
+                policy.WithOrigins(corsOptions.AllowedOrigins)
+                    .AllowAnyMethod()
+                    .AllowAnyHeader()
+                    .AllowCredentials();
+            });
+        });
+    }
     private static void AddServices(IServiceCollection services)
         => services.AddScoped<IJwtService, JwtService>();
 }

--- a/Portify.API/appsettings.Development.json
+++ b/Portify.API/appsettings.Development.json
@@ -23,5 +23,8 @@
     "Issuer": "Portify.API",
     "Audience": "Portify.Users",
     "ExpiryMinutes": 60
+  },
+  "Cors": {
+    "AllowedOrigins": [ "https://localhost:3000"]
   }
 }

--- a/Portify.Domain/Portify.Domain.csproj
+++ b/Portify.Domain/Portify.Domain.csproj
@@ -20,4 +20,8 @@
     <ProjectReference Include="..\Portify.Shared\Portify.Shared.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.6" />
+  </ItemGroup>
+
 </Project>

--- a/Portify.Infrastructure/Configuration/Settings/CorsOptions.cs
+++ b/Portify.Infrastructure/Configuration/Settings/CorsOptions.cs
@@ -1,0 +1,10 @@
+namespace Portify.Infrastructure.Configuration.Settings;
+
+   public sealed class CorsOptions
+{
+    public const string PolicyName = "PortifyCorsPolicy";
+    public const string SectionName = "Cors";
+
+    public required string[] AllowedOrigins { get; init; }
+}
+


### PR DESCRIPTION
This pull request introduces Cross-Origin Resource Sharing (CORS) support to the `Portify.API` project, along with a few other updates. The most significant changes include adding a CORS policy configuration, updating the `appsettings.Development.json` file to include allowed origins, and adding a new dependency to the `Portify.Domain` project.

### CORS Support:

* **CORS Policy Configuration**: Added a new `CorsOptions` class in `Portify.Infrastructure/Configuration/Settings` to encapsulate CORS settings, including `PolicyName` and `AllowedOrigins`.
* **Service Registration**: Introduced the `AddCorsPolicy` method in `ServiceConfiguration.cs` to register the CORS policy with the allowed origins specified in the configuration.
* **Middleware Integration**: Updated `Program.cs` to apply the CORS policy middleware using `app.UseCors(CorsOptions.PolicyName)`.

### Configuration Updates:

* **Development Configuration**: Updated `appsettings.Development.json` to include a new `Cors` section with `AllowedOrigins` set to `https://localhost:3000`.
* 
**The "AllowedOrigins": [ "https://localhost:3000"] configuration in the appsettings.Development.json file specifies the origins allowed for Cross-Origin Resource Sharing (CORS). This means that only requests originating from https://localhost:3000 will be permitted to access the API when CORS is enabled.**

### Dependency Updates:

* **EF Core Dependency**: Added a reference to `Microsoft.EntityFrameworkCore` version `9.0.6` in `Portify.Domain.csproj`.
